### PR TITLE
Update UserGuide.md

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -902,6 +902,23 @@ testers are expected to do more *exploratory* testing.
    1. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)<br>
       Expected: Similar to previous.
 
+### Sorting a task
+
+1. Sorting different types of tasks
+
+   1. Prerequisites: Add 1 of `Events`, `Deadline`, `SimpleTask` in the order stated with a tag of liking to it. Then, repeat it again, but with no tags assigned to each.
+
+   1. Test case: `sort`<br>
+     Expected: The order of the tags will be as follows: `SimpleTask` with no tag, `SimpleTask` with tag, `Deadline` with no tags, `Deadline` with tags, `Event` with no tags, `Event` with tags.
+
+2. Sorting a `Deadline` with different deadlines
+   
+   1. Prerequisites: Add 1 `Deadline` task with a deadline of liking (e.g. 2023-04-14 1400) and another `Deadline` task with an earlier deadline (e.g. 2023-04-14 1200).
+  
+   1. Test case: `sort`<br>
+     Expected: The `Deadline` task with an earlier deadline is above the other.
+
+
 ### Set an alert window
 
 1. Add a task that starts or ends within 24 hours
@@ -922,9 +939,12 @@ testers are expected to do more *exploratory* testing.
 
 1. Dealing with missing/corrupted data files
 
-   1. _{explain how to simulate a missing/corrupted file, and the expected behavior}_
+   1. Prerequisites: Locate the `data` folder in the same directory as where the jar file is located. (If the data folder is not yet generated, add a dummy task `add n/dummyTask` to generate one).
 
-1. _{ more test cases …​ }_
+   1. Exit the application and delete the `data` folder.
+
+   1. Open the application again.
+      Expected: A list of sample Task is displayed.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -906,7 +906,7 @@ testers are expected to do more *exploratory* testing.
 
 1. Sorting different types of tasks
 
-   1. Prerequisites: Add 1 of `Events`, `Deadline`, `SimpleTask` in the order stated with a tag of liking to it. Then, repeat it again, but with no tags assigned to each.
+   1. Prerequisites: Add 1 each of `Events`, `Deadline`, `SimpleTask` in the order stated with a tag of liking to it. Then, repeat it again, but with no tags assigned to each.
 
    1. Test case: `sort`<br>
      Expected: The order of the tags will be as follows: `SimpleTask` with no tag, `SimpleTask` with tag, `Deadline` with no tags, `Deadline` with tags, `Event` with no tags, `Event` with tags.

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -924,14 +924,18 @@ testers are expected to do more *exploratory* testing.
 1. Add a task that starts or ends within 24 hours
    1. Prerequisites: It is the first start-up of Clock-Work with no `alert` command calls. OR <br>
     User has already called `alert 24`.
+
    1. Test case: `add n/Test D/2023-04-08 0900` assuming that is it currently `2023-04-07 1000` <br>
     Expected: Task added to the task list. Details of added task shown in status message. <br>
     If it is first time start up of Clock-Work or alert window already set to 24, the task should already appear in the alert window.
+
 2. Add a task that starts or ends within 48 hours
    1. Prerequisites: It is the first start-up of Clock-Work with no changes `alert` command calls. OR <br>
       User has already called `alert` with an alert window less than 48 hours.
+
    1. Set up: `add n/Test D/2023-04-09 0900` assuming that is it currently `2023-04-07 1000` <br>
       Expected: Task added to the task list. Details of added task shown in status message. <br>
+
    1. Test case: `alert 48`. <br>
    Expected: The task should already appear in the alert window.
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -943,7 +943,7 @@ testers are expected to do more *exploratory* testing.
 
    1. Exit the application and delete the `data` folder.
 
-   1. Open the application again.
+   1. Open the application again. <br>
       Expected: A list of sample Task is displayed.
 
 --------------------------------------------------------------------------------------------------------------------

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -235,6 +235,8 @@ e.g. `edit 1 t/CS2102 t/CS2102` will only register t/CS2102 once!
 
 :man_technologist: **Congratulations! You have completed a task. Now, you can remove it by using this command.**
 
+:man_technologist: **Think twice before using this. This action is not reversible.**
+
 Deletes the specified task from the task  book.
 
 Format: `delete INDEX [INDEX]…​`
@@ -314,8 +316,8 @@ Examples:
     * e.g. `find all/ n/try n/try n/lab` is interpreted as `find all/ n/try n/lab`
 * For tags, if you do not specify the `all/` prefix, as long as one tag matches with one of the tags you are searching for, it will be considered matched.
   However, adding `all/` means that a task which contains all your tag inputs will be displayed.
-    * e.g. `find t/very urgent t/important` will match with tags `t/very very urgent t/math t/hard` since it has `very urgent`.
-    * e.g. `find all/ t/very urgent t/important` will match with tags `t/very urgent t/important` since it has both tags.
+    * e.g. `find t/veryUrgent t/important` will match with tags `t/veryVeryUrgent t/math t/hard` since it has `veryurgent`.
+    * e.g. `find all/ t/veryUrgent t/important` will match with tags `t/veryUrgent t/important` since it has both tags.
 
 :warning: When searching for a description `find d/DESCRIPTION`, Tasks without user's input description will not show up!
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -236,8 +236,6 @@ e.g. `edit 1 t/CS2102 t/CS2102` will only register t/CS2102 once!
 
 :man_technologist: **Congratulations! You have completed a task. Now, you can remove it by using this command.**
 
-:man_technologist: **Think twice before using this. This action is not reversible.**
-
 Deletes the specified task from the task  book.
 
 Format: `delete INDEX [INDEX]…​`
@@ -424,8 +422,6 @@ Format: `help`
 
 
 ### 3.12 Clearing all entries : `clear`
-
-:man_technologist: **Think twice before using this. This action is not reversible.**
 
 Clears all entries from the task book.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -217,6 +217,7 @@ Format: `edit INDEX [n/TASKNAME] [d/DESCRIPTION] [E/EFFORT] [t/TAG]…​`
 
 * Edits the task at the specified `INDEX`. The index refers to the index number shown in the displayed task list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
+* `DEADLINE`, `FROMDATE`, `TODATE` can also be altered if and only if the original tasks has these fields. (You are unable to assign a `deadline` to a `SimpleTask`).
 * Existing values will be updated to the input values.
 * When editing tags, the existing tags of the task will be removed i.e adding of tags is not cumulative.
 * You can remove all the task’s tags by typing `t/` without specifying any tags after it.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -285,7 +285,7 @@ Sorts the list using the following format:
         * The task with the earlier `from` attribute is listed above the task with a later `from` attribute.
         * Else if both task have the same `from` attribute, the task with the earlier `to` attribute is listed above the task with later `to` attribute.
         * Else if both task have the same `to` attribute, the task with lesser tags is listed above the task with more tags.
-        * Else if both tasks have the same number of tags, the task with a smaller lexicgraphical name is listed above the other.
+        * Else if both tasks have the same number of tags, the task with a smaller lexicographical name is listed above the other.
 
 
 Format: `sort`
@@ -664,6 +664,6 @@ _Details coming soon ..._
 
 ## 7. Glossary
 1. Free day: Allocating a task to this day will not result in total allocated effort exceeding preferred effort level.
-2. Long date: Date in the format YYYY-MM-DD HHMM
-3. Short date: Date in the format YYYY-MM-DD
+2. Long date: Date in the format YYYY-MM-DD HHMM.
+3. Short date: Date in the format YYYY-MM-DD.
 4. Overload: When the sum of effort for all tasks allocated to a particular day exceeds the preferred daily effort level.

--- a/src/main/java/seedu/task/MainApp.java
+++ b/src/main/java/seedu/task/MainApp.java
@@ -40,7 +40,7 @@ import seedu.task.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(1, 3, 0, true);
+    public static final Version VERSION = new Version(1, 4, 0, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 

--- a/src/main/java/seedu/task/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/task/logic/commands/SortCommand.java
@@ -12,7 +12,7 @@ public class SortCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": sorts the list.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String SORT_SUCCESS_MESSAGE = "List sorted.";
+    public static final String SORT_SUCCESS_MESSAGE = "Task List sorted.";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/task/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/task/logic/commands/SortCommand.java
@@ -12,7 +12,7 @@ public class SortCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": sorts the list.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String SORT_SUCCESS_MESSAGE = "Task List sorted.";
+    public static final String SORT_SUCCESS_MESSAGE = "Task list sorted.";
 
     @Override
     public CommandResult execute(Model model) {


### PR DESCRIPTION
Add irreversible delete warning. Closes #176 
Edit tags in find example to be only one word. Closes #170
Add ability to edit dates to edit. Closes #162
Edit typo in SortCommand error message. Closes #177
Update DG with manual testing for storage and sort. 